### PR TITLE
Missing require_once statements in batch import

### DIFF
--- a/modules/islandora_simple_xml_batch/islandora_simple_xml_batch.drush.inc
+++ b/modules/islandora_simple_xml_batch/islandora_simple_xml_batch.drush.inc
@@ -5,6 +5,9 @@
  * Implementation of Drush hooks.
  */
 
+require_once 'includes/preprocessor.inc';
+require_once 'includes/object.inc';
+
 /**
  * Implements hook_drush_command().
  */


### PR DESCRIPTION
Add `require_once` statements for preprocessor.inc and object.inc files in the batch command. It doesn't seem to respect .info `files[]` directives.
